### PR TITLE
Computing Zeta Function from Recurrence Relation

### DIFF
--- a/thagomizer.sage
+++ b/thagomizer.sage
@@ -71,4 +71,4 @@ def check_thag_tzf(n):
 
 	print(difference)
 
-check_thag_tzf(6)
+#check_thag_tzf(6)


### PR DESCRIPTION
Added a new function, tzf_recurrence, to matroidzeta.sage to compute
the topological zeta function of a matroid M via the recurrence relation
summing over all proper flats in L(M).

Also modified thagomizer.sage to prevent a computation being run on
loading the file.

robert.miranda@yale.edu